### PR TITLE
Released the GIL

### DIFF
--- a/tgcrypto/tgcrypto.c
+++ b/tgcrypto/tgcrypto.c
@@ -51,7 +51,9 @@ static PyObject *ige(PyObject *args, uint8_t encrypt) {
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     buf = ige256(data.buf, data.len, key.buf, iv.buf, encrypt);
+    Py_END_ALLOW_THREADS
 
     PyBuffer_Release(&data);
     PyBuffer_Release(&key);
@@ -104,7 +106,9 @@ static PyObject *ctr256_encrypt(PyObject *self, PyObject *args) {
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     buf = ctr256(data.buf, data.len, key.buf, iv.buf, state.buf);
+    Py_END_ALLOW_THREADS
 
     PyBuffer_Release(&data);
     PyBuffer_Release(&key);
@@ -144,7 +148,9 @@ static PyObject *cbc(PyObject *args, uint8_t encrypt) {
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     buf = cbc256(data.buf, data.len, key.buf, iv.buf, encrypt);
+    Py_END_ALLOW_THREADS
 
     PyBuffer_Release(&data);
     PyBuffer_Release(&key);


### PR DESCRIPTION
released the GIL to make use of multiple cores when using multithreading.

as per [the docs](https://docs.python.org/3/c-api/init.html#releasing-the-gil-from-extension-code):
>Calling system I/O functions is the most common use case for releasing the GIL, but it can also be useful before calling long-running computations which don’t need access to Python objects, such as compression or **cryptographic functions operating over memory buffers**. For example, the standard zlib and hashlib modules release the GIL when compressing or hashing data.