### PR TITLE
Add type hinting for functions

### DIFF
--- a/tgcrypto/tgcrypto.pyi
+++ b/tgcrypto/tgcrypto.pyi
@@ -1,0 +1,12 @@
+def ige256_encrypt(data: bytes, key: bytes, iv: bytes) -> bytes:
+    """AES256-IGE Encryption"""
+def ige256_decrypt(data: bytes, key: bytes, iv: bytes) -> bytes:
+    """AES256-IGE Decryption"""
+def ctr256_encrypt(data: bytes, key: bytes, iv: bytes, state: bytes) -> bytes:
+    """AES256-CTR Encryption"""
+def ctr256_decrypt(data: bytes, key: bytes, iv: bytes, state: bytes) -> bytes:
+    """AES256-CTR Decryption"""
+def cbc256_encrypt(data: bytes, key: bytes, iv: bytes) -> bytes:
+    """AES256-CBC Encryption"""
+def cbc256_decrypt(data: bytes, key: bytes, iv: bytes) -> bytes:
+    """AES256-CBC Decryption"""


### PR DESCRIPTION
Now you can see function's arguments in IDE instead of "*args, **kwargs".
