### PR TITLE
Exclude `tests` from the distributed wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "Documentation": "https://docs.pyrogram.org",
     },
     python_requires="~=3.7",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     test_suite="tests",
     zip_safe=False,
     ext_modules=[


### PR DESCRIPTION
From what I can tell, it is discouraged to have a top-level directory named `tests` distributed alongside with the package: https://wiki.archlinux.org/title/Python_package_guidelines#Test_directory_in_site-package So this PR excludes it from the final `.whl` being built.

To the best of my understanding, it broke neither the deprecated `python3 setup.py test`, not the `tox`, or `pytest`. However, it might have broken someone's code if it relied on tgcrypto being distributed alongside with the tests. In which case, WTF.

Anyways, this most likely needs a version bump of some sorts, no matter the breakingness of the change.
