### PR TITLE
Update wheels.yml

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,13 +8,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.21.3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_TEST_REQUIRES: tox
@@ -22,7 +27,7 @@ jobs:
           CIBW_TEST_SKIP: "*-win*"
           CIBW_BUILD_VERBOSITY: 1
 
-      - name: Store wheels
-        uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
Workflow doesnt work because upload-artifact@v2 is deprecated, I used the official example to make some changes (https://github.com/pypa/cibuildwheel#example-setup).